### PR TITLE
Monit 9728/add nodejs lambda wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install wavefront-lambda
 ```
 
 ## Environment variables
-WAVEFRONT_URL = <INSTANCE>.wavefront.com  
+WAVEFRONT_URL = \<INSTANCE>.wavefront.com  
 WAVEFRONT_API_TOKEN = Wavefront API token with Direct Data Ingestion permission.  
 REPORT_STANDARD_METRICS = Set to False or false to not report standard lambda metrics directly to wavefront.  
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
 # wavefront-lambda-nodejs
+
+This is a Wavefront Go wrapper for AWS Lambda to enable reporting standard lambda metrics and custom app metrics directly to wavefront.
+
+## Requirements
+Go 1.x
+
+## Installation
+```
+npm install wavefront-lambda
+```
+
+## Environment variables
+WAVEFRONT_URL = https://\<INSTANCE>.wavefront.com  
+WAVEFRONT_API_TOKEN = Wavefront API token with Direct Data Ingestion permission.  
+REPORT_STANDARD_METRICS = Set to False or false to not report standard lambda metrics directly to wavefront.  
+
+## Usage
+
+Wrap your AWS Lambda handler function.
+
+```javascript
+const wavefrontLambda = require('wavefront-lambda')
+const metrics = require('wavefrontmetrics');
+
+exports.myHandler = wavefrontLambda.wrapper(function(event, context, callback) {
+  // your code
+});
+```
+
+## Standard Lambda Metrics reported by Wavefront Lambda wrapper
+
+The Lambda wrapper sends the following standard lambda metrics to wavefront:
+
+| Metric Name                       |  Type              | Description                                                             |
+| ----------------------------------|:------------------:| ----------------------------------------------------------------------- |
+| aws.lambda.wf.invocations.count   | Delta Counter      | Count of number of lambda function invocations aggregated at the server.|
+| aws.lambda.wf.invocation_event.count   |  Counter      | Count of number of lambda function invocations.|
+| aws.lambda.wf.errors.count        | Delta Counter      | Count of number of errors aggregated at the server.                     |
+| aws.lambda.wf.error_event.count        |  Counter      | Count of number of errors.                     |
+| aws.lambda.wf.coldstarts.count    | Delta Counter      | Count of number of cold starts aggregated at the server.                |
+| aws.lambda.wf.coldstart_event.count| Counter           | Count of number of cold starts.                                         |
+| aws.lambda.wf.duration.value      | Gauge              | Execution time of the Lambda handler function in milliseconds.          |
+
+The Lambda wrapper adds the following point tags to all metrics sent to wavefront:
+
+| Point Tag             | Description                                                                   |
+| --------------------- | ----------------------------------------------------------------------------- |
+| LambdaArn             | ARN(Amazon Resource Name) of the Lambda function.                             |
+| Region                | AWS Region of the Lambda function.                                            |
+| accountId             | AWS Account ID from which the Lambda function was invoked.                    |
+| ExecutedVersion       | The version of Lambda function.                                               |
+| FunctionName          | The name of Lambda function.                                                  |
+| Resource              | The name and version/alias of Lambda function. (Ex: DemoLambdaFunc:aliasProd) |
+| EventSourceMappings   | AWS Event source mapping Id. (Set in case of Lambda invocation by AWS Poll-Based Services)|
+
+## Custom Lambda Metrics
+
+The wavefront nodejs lambda wrapper reports custom business metrics via API's provided by the [nodejs-metrics-wavefront client] (https://github.com/wavefrontHQ/nodejs-metrics-wavefront).  
+Please refer to the below code sample which shows how you can send custom business metrics to wavefront from your lambda function.
+
+### Code Sample
+
+```javascript
+const wavefrontLambda = require('wavefront-lambda')
+const metrics = require('wavefrontmetrics');
+
+exports.myHandler = wavefrontLambda.wrapper(function(event, context, callback) {
+  // Get registry to report metrics.
+  let registry = wavefrontLambda.getRegistry();
+
+  // Register and report Counters with app tags.
+  let counter = new metrics.Counter();
+  registry.addTaggedMetric("sample.counter.count", counter, {"key1":"val1"});
+  counter.inc();
+
+  // Register and report Delta Counters with app tags.
+  let deltaCounter = new metrics.Counter();
+  let deltaCounterName = metrics.deltaCounterName("sample.deltaCounter.count");
+  registry.addTaggedMetric(deltaCounterName, deltaCounter, {"key1":"val1"});
+  deltaCounter.inc();
+
+  callback(null, "some success message");
+  // or
+  // callback("some error type");
+});
+
+```
+
+Note: Having the same metric name for any two types of metrics will result in only one time series at the server and thus cause collisions.
+In general, all metric names should be different. In case you have metrics that you want to track as both a Counter and Delta Counter, consider adding a relevant suffix to one of the metrics to differentiate one metric name from another.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install wavefront-lambda
 ```
 
 ## Environment variables
-WAVEFRONT_URL = https://\<INSTANCE>.wavefront.com  
+WAVEFRONT_URL = <INSTANCE>.wavefront.com  
 WAVEFRONT_API_TOKEN = Wavefront API token with Direct Data Ingestion permission.  
 REPORT_STANDARD_METRICS = Set to False or false to not report standard lambda metrics directly to wavefront.  
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Wavefront Go wrapper for AWS Lambda to enable reporting standard lambda metrics and custom app metrics directly to wavefront.
 
 ## Requirements
-Go 1.x
+Node.js runtime v8.10
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wavefront-lambda-nodejs
 
-This is a Wavefront Go wrapper for AWS Lambda to enable reporting standard lambda metrics and custom app metrics directly to wavefront.
+This is a Wavefront Nodejs wrapper for AWS Lambda to enable reporting standard lambda metrics and custom app metrics directly to wavefront.
 
 ## Requirements
 Node.js runtime v8.10

--- a/lib/asyncWrapper.js
+++ b/lib/asyncWrapper.js
@@ -1,0 +1,50 @@
+const wavefrontReporter = require('./reporter');
+const AsyncFunction = (async () => {}).constructor;
+
+const handleSuccess =(context, startTime)=> {
+  // Update Duration
+  wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
+  console.log("CALCULATE:: duration from then() ")
+  wavefrontReporter.reportMetrics(context);
+}
+
+const handleError = (context, startTime) => {
+  // Increment error counter.
+  wavefrontReporter.incrementErrors();
+  // Update Duration
+  wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
+  console.log("INCREMENT:: Error counter and calculate duration from catch")
+  wavefrontReporter.reportMetrics(context);
+}
+
+const generateAsyncWrapper = ((lambdaHandlerFunction) => async function (event, context) {
+        // Register standard lambda metrics with the registry.
+        wavefrontReporter.registerStandardLambdaMetrics();
+        // Increment invocation counter.
+        wavefrontReporter.incrementInvocations();
+        startTime = process.hrtime();
+        return lambdaHandlerFunction(event, context)
+        .then((data) => {
+          handleSuccess(context, startTime);
+          return data;
+        })
+        .catch((error) => {
+          handleError(context, startTime);
+          throw error;
+        });
+});
+
+const wrapper = lambdaHandlerFunction => {
+  if(lambdaHandlerFunction instanceof AsyncFunction === true){
+    return generateAsyncWrapper(lambdaHandlerFunction);
+  } else {
+    let generateWrapper = require('./wrapper');
+    return generateWrapper.wrapper(lambdaHandlerFunction);
+  }
+};
+
+const getRegistry = function(){
+  return wavefrontReporter.getRegistry();
+}
+
+module.exports = {wrapper, getRegistry};

--- a/lib/asyncWrapper.js
+++ b/lib/asyncWrapper.js
@@ -1,4 +1,5 @@
 const wavefrontReporter = require('./reporter');
+const generateWrapper = require('./wrapper');
 const AsyncFunction = (async () => {}).constructor;
 
 const handleSuccess =(context, startTime)=> {
@@ -37,7 +38,6 @@ const wrapper = lambdaHandlerFunction => {
   if(lambdaHandlerFunction instanceof AsyncFunction === true){
     return generateAsyncWrapper(lambdaHandlerFunction);
   } else {
-    let generateWrapper = require('./wrapper');
     return generateWrapper.wrapper(lambdaHandlerFunction);
   }
 };

--- a/lib/asyncWrapper.js
+++ b/lib/asyncWrapper.js
@@ -22,7 +22,7 @@ const generateAsyncWrapper = ((lambdaHandlerFunction) => async function (event, 
         wavefrontReporter.registerStandardLambdaMetrics();
         // Increment invocation counter.
         wavefrontReporter.incrementInvocations();
-        startTime = process.hrtime();
+        let startTime = process.hrtime();
         return lambdaHandlerFunction(event, context)
         .then((data) => {
           handleSuccess(context, startTime);

--- a/lib/asyncWrapper.js
+++ b/lib/asyncWrapper.js
@@ -4,7 +4,6 @@ const AsyncFunction = (async () => {}).constructor;
 const handleSuccess =(context, startTime)=> {
   // Update Duration
   wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
-  console.log("CALCULATE:: duration from then() ")
   wavefrontReporter.reportMetrics(context);
 }
 
@@ -13,7 +12,6 @@ const handleError = (context, startTime) => {
   wavefrontReporter.incrementErrors();
   // Update Duration
   wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
-  console.log("INCREMENT:: Error counter and calculate duration from catch")
   wavefrontReporter.reportMetrics(context);
 }
 
@@ -22,6 +20,7 @@ const generateAsyncWrapper = ((lambdaHandlerFunction) => async function (event, 
         wavefrontReporter.registerStandardLambdaMetrics();
         // Increment invocation counter.
         wavefrontReporter.incrementInvocations();
+        // Record start time to calculate duration of execution of original lambda function.
         let startTime = process.hrtime();
         return lambdaHandlerFunction(event, context)
         .then((data) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,36 @@
+const server = process.env.WAVEFRONT_URL;
+const authToken = process.env.WAVEFRONT_API_TOKEN;
+const isReportStandardMetrics = process.env.REPORT_STANDARD_METRICS !== 'False' && process.env.REPORT_STANDARD_METRICS  !== 'false'
+const metricPrefix = "aws.lambda.wf.";
+const standardLambdaMetrics = {
+  invocationsCounter : metricPrefix + 'invocations.count',
+  invocationEventCounter : metricPrefix + 'invocation_event.count',
+  coldStartsCounter : metricPrefix + 'coldstarts.count',
+  coldStartEventCounter : metricPrefix + 'coldstart_event.count',
+  errorsCounter : metricPrefix + 'errors.count',
+  errorEventCounter : metricPrefix + 'error_event.count',
+  durationValue : metricPrefix + 'duration.value'
+};
+
+let isColdStart = true;
+// const validateAndGetLambdaEnvironment = () => {
+if (!server || !server.length) {
+  throw new Error('Environment variable WAVEFRONT_URL is not set.');
+}
+if (!authToken || !authToken.length) {
+  throw new Error('Environment variable WAVEFRONT_API_TOKEN is not set.');
+}
+//   reportStandardMetrics = process.env.IS_REPORT_STANDARD_METRICS
+//   if (reportStandardMetrics === 'False' || reportStandardMetrics === 'false') {
+//     return false;
+//   }
+//   return true;
+// }
+
+module.exports = {
+  server,
+  authToken,
+  isReportStandardMetrics,
+  standardLambdaMetrics,
+  isColdStart
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,10 +3,10 @@ const authToken = process.env.WAVEFRONT_API_TOKEN;
 const isReportStandardMetrics = process.env.REPORT_STANDARD_METRICS !== 'False' && process.env.REPORT_STANDARD_METRICS  !== 'false'
 
 // Validate Environment variables.
-if (!server || !server.length) {
+if (!server) {
   throw new Error('Environment variable WAVEFRONT_URL is not set.');
 }
-if (!authToken || !authToken.length) {
+if (!authToken) {
   throw new Error('Environment variable WAVEFRONT_API_TOKEN is not set.');
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,19 @@
 const server = process.env.WAVEFRONT_URL;
 const authToken = process.env.WAVEFRONT_API_TOKEN;
 const isReportStandardMetrics = process.env.REPORT_STANDARD_METRICS !== 'False' && process.env.REPORT_STANDARD_METRICS  !== 'false'
+
+// Validate Environment variables.
+if (!server || !server.length) {
+  throw new Error('Environment variable WAVEFRONT_URL is not set.');
+}
+if (!authToken || !authToken.length) {
+  throw new Error('Environment variable WAVEFRONT_API_TOKEN is not set.');
+}
+
+// Metric prefix for all standard lambda metrics reported by wrapper.
 const metricPrefix = "aws.lambda.wf.";
+
+// Standard Lambda Metrics reported by wrapper.
 const standardLambdaMetrics = {
   invocationsCounter : metricPrefix + 'invocations.count',
   invocationEventCounter : metricPrefix + 'invocation_event.count',
@@ -11,21 +23,7 @@ const standardLambdaMetrics = {
   errorEventCounter : metricPrefix + 'error_event.count',
   durationValue : metricPrefix + 'duration.value'
 };
-
 let isColdStart = true;
-// const validateAndGetLambdaEnvironment = () => {
-if (!server || !server.length) {
-  throw new Error('Environment variable WAVEFRONT_URL is not set.');
-}
-if (!authToken || !authToken.length) {
-  throw new Error('Environment variable WAVEFRONT_API_TOKEN is not set.');
-}
-//   reportStandardMetrics = process.env.IS_REPORT_STANDARD_METRICS
-//   if (reportStandardMetrics === 'False' || reportStandardMetrics === 'false') {
-//     return false;
-//   }
-//   return true;
-// }
 
 module.exports = {
   server,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 const config = require('./config')
 let wrapper;
-//Check if functions is async for nodejs runtimes greater than 8.0
+// Check if nodejs runtime is greater than v8.0.
+// If so return wrapper which can handle async functions.
 if (parseInt(process.version.substring(1,2)) >= 8){
-    console.log("In lib/index.js")
     wrapper = require('./asyncWrapper')
   } else {
     wrapper = require('./wrapper');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,11 @@
+const config = require('./config')
+let wrapper;
+//Check if functions is async for nodejs runtimes greater than 8.0
+if (parseInt(process.version.substring(1,2)) >= 8){
+    console.log("In lib/index.js")
+    wrapper = require('./asyncWrapper')
+  } else {
+    wrapper = require('./wrapper');
+  }
+
+module.exports = wrapper

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
-const config = require('./config')
+const config = require('./config');
+const semver = require('semver');
 let wrapper;
 // Check if nodejs runtime is greater than v8.0.
 // If so return wrapper which can handle async functions.
-if (parseInt(process.version.substring(1,2)) >= 8){
-    wrapper = require('./asyncWrapper')
+if (semver.gte(process.version, '8.0.0')){
+    wrapper = require('./asyncWrapper');
   } else {
     wrapper = require('./wrapper');
   }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,15 +1,8 @@
 const metrics = require('wavefrontmetrics');
 const config = require('./config');
 
-var registry;
-let invocationsCounter;
-let invocationEventCounter;
-let coldStartsCounter;
-let coldStartEventCounter;
-let errorsCounter;
-let errorEventCounter;
-let durationValue;
-
+let registry;
+let standardMetrics;
 
 const registerStandardLambdaMetrics = () => {
   // Initiate Registry
@@ -19,33 +12,19 @@ const registerStandardLambdaMetrics = () => {
     return;
   }
 
-  // Register Invocation counter
-  invocationEventCounter = new metrics.Counter();
-  registry.addTaggedMetric(config.standardLambdaMetrics.invocationEventCounter, invocationEventCounter);
+  let standardMetricsKeys = Object.keys(config.standardLambdaMetrics).map(key => config.standardLambdaMetrics[key]);
 
-  invocationsCounter = new metrics.Counter();
-  let invocationsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.invocationsCounter);
-  registry.addTaggedMetric(invocationsCounterName, invocationsCounter);
-
-  // Register Error Counter
-  errorEventCounter = new metrics.Counter();
-  registry.addTaggedMetric(config.standardLambdaMetrics.errorEventCounter, errorEventCounter);
-
-  errorsCounter = new metrics.Counter();
-  let errorsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.errorsCounter);
-  registry.addTaggedMetric(errorsCounterName, errorsCounter);
-
-	// Register cold start counter.
-  coldStartEventCounter = new metrics.Counter();
-  registry.addTaggedMetric(config.standardLambdaMetrics.coldStartEventCounter, coldStartEventCounter);
-
-  coldStartsCounter = new metrics.Counter();
-  let coldStartsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.coldStartsCounter);
-  registry.addTaggedMetric(coldStartsCounterName, coldStartsCounter);
-
-  // Register duration as Counter.
-  durationValue = new metrics.Counter();
-  registry.addTaggedMetric(config.standardLambdaMetrics.durationValue, durationValue);
+  // Register Standard Lambda Metrics as Counters.
+  standardMetrics = standardMetricsKeys.reduce((metricObj, name) => {
+      metricObj[name] = new metrics.Counter();
+      if(name.includes('event') || name.includes('value')) {
+        registry.addTaggedMetric(name, metricObj[name]);
+      } else{
+        let deltaName = metrics.deltaCounterName(name);
+        registry.addTaggedMetric(deltaName, metricObj[name]);
+      }
+      return metricObj;
+  }, {});
 
   if(config.isColdStart){
     //Update cold start counter.
@@ -61,31 +40,7 @@ const incrementMetric = function (metricName, value) {
   if (!config.isReportStandardMetrics) {
     return;
   }
-  switch (metricName) {
-    case config.standardLambdaMetrics.invocationsCounter:
-        invocationsCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.invocationEventCounter:
-        invocationEventCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.errorsCounter:
-        errorsCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.errorEventCounter:
-        errorEventCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.coldStartsCounter:
-        coldStartsCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.coldStartEventCounter:
-        coldStartEventCounter.inc(value);
-        break;
-    case config.standardLambdaMetrics.durationValue:
-        durationValue.inc(value);
-        break;
-    default:
-         console.warn("No standard lambda metric matched.");
-  }
+  standardMetrics[metricName].inc(value);
 }
 
 const incrementInvocations = function(){

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,0 +1,157 @@
+const metrics = require('wavefrontmetrics');
+const config = require('./config')
+
+var registry;
+let invocationsCounter;
+let invocationEventCounter;
+let coldStartsCounter;
+let coldStartEventCounter;
+let errorsCounter;
+let errorEventCounter;
+let durationValue;
+
+
+const registerStandardLambdaMetrics = () => {
+  // Initiate Registry
+  registry = new metrics.Registry();
+  // Return if reportStandardLambdaMetrics is disabled.
+  if(!config.isReportStandardMetrics){
+    return;
+  }
+
+  // Register Invocation counter
+  invocationEventCounter = new metrics.Counter();
+  registry.addTaggedMetric(config.standardLambdaMetrics.invocationEventCounter, invocationEventCounter);
+
+  invocationsCounter = new metrics.Counter();
+  let invocationsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.invocationsCounter);
+  registry.addTaggedMetric(invocationsCounterName, invocationsCounter);
+
+  // Register Error Counter
+  errorEventCounter = new metrics.Counter();
+  registry.addTaggedMetric(config.standardLambdaMetrics.errorEventCounter, errorEventCounter);
+
+  errorsCounter = new metrics.Counter();
+  let errorsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.errorsCounter);
+  registry.addTaggedMetric(errorsCounterName, errorsCounter);
+
+	// Register cold start counter.
+  coldStartEventCounter = new metrics.Counter();
+  registry.addTaggedMetric(config.standardLambdaMetrics.coldStartEventCounter, coldStartEventCounter);
+
+  coldStartsCounter = new metrics.Counter();
+  let coldStartsCounterName = metrics.deltaCounterName(config.standardLambdaMetrics.coldStartsCounter);
+  registry.addTaggedMetric(coldStartsCounterName, coldStartsCounter);
+
+  // Register duration as Counter.
+  durationValue = new metrics.Counter();
+  registry.addTaggedMetric(config.standardLambdaMetrics.durationValue, durationValue);
+
+  if(config.isColdStart){
+    //Update cold start counter.
+    incrementColdStarts()
+    config.isColdStart = false;
+  }
+}
+
+// Function to increment or update the given metric with the given value.
+// This method should only be used to handle updating values of standardLambdaMetrics
+// defined in ./config.js
+const incrementMetric = function (metricName, value) {
+  if (!config.isReportStandardMetrics) {
+    return;
+  }
+  switch (metricName) {
+    case config.standardLambdaMetrics.invocationsCounter:
+        invocationsCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.invocationEventCounter:
+        invocationEventCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.errorsCounter:
+        errorsCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.errorEventCounter:
+        errorEventCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.coldStartsCounter:
+        coldStartsCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.coldStartEventCounter:
+        coldStartEventCounter.inc(value);
+        break;
+    case config.standardLambdaMetrics.durationValue:
+        durationValue.inc(value);
+        break;
+    default:
+         console.log("Warn :: No standard lambda metric was matched.");
+  }
+}
+
+const incrementInvocations = function(){
+  incrementMetric(config.standardLambdaMetrics.invocationEventCounter, 1)
+  incrementMetric(config.standardLambdaMetrics.invocationsCounter, 1)
+}
+
+const incrementErrors = function(){
+  incrementMetric(config.standardLambdaMetrics.errorEventCounter, 1)
+  incrementMetric(config.standardLambdaMetrics.errorsCounter, 1)
+}
+
+const incrementColdStarts = function(){
+  incrementMetric(config.standardLambdaMetrics.coldStartEventCounter, 1)
+  incrementMetric(config.standardLambdaMetrics.coldStartsCounter, 1)
+}
+
+const updateDuration = function(value){
+  incrementMetric(config.standardLambdaMetrics.durationValue, value)
+}
+
+const getRegistry = () => {
+  return registry;
+}
+
+const reportMetrics = (context) =>  {
+  if(context != null){
+    let invokedFunctionArn = context.invokedFunctionArn
+    let splitArn = invokedFunctionArn.split(":")
+
+    // Expected formats for Lambda ARN are:
+    // https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-lambda
+    let tags = {
+      "LambdaArn":       invokedFunctionArn,
+      "source":          context.functionName,
+      "FunctionName":    context.functionName,
+      "ExecutedVersion": context.functionVersion,
+      "Region":          splitArn[3],
+      "accountId":       splitArn[4]
+    }
+    if (splitArn[5] === "function") {
+      tags["Resource"] = splitArn[6]
+      if (splitArn.length === 8) {
+        tags["Resource"] += ":" + splitArn[7]
+      }
+    } else if (splitArn[5] === "event-source-mappings") {
+      tags["EventSourceMappings"] = splitArn[6]
+    }
+
+    try{
+      let directReporter = new metrics.WavefrontDirectReporter(registry, "", config.server, config.authToken, tags);
+      directReporter.report()
+    }catch(exception){
+      console.warn('Failed to report metrics to wavefront.');
+    }
+  }else{
+    console.warn('Failed to report metrics to wavefront as retrieving lambdaContext from AWS failed.');
+  }
+}
+
+module.exports = {
+  registerStandardLambdaMetrics,
+  incrementInvocations,
+  incrementErrors,
+  incrementColdStarts,
+  updateDuration,
+  reportMetrics,
+  getRegistry
+};

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,5 @@
 const metrics = require('wavefrontmetrics');
-const config = require('./config')
+const config = require('./config');
 
 var registry;
 let invocationsCounter;
@@ -113,8 +113,9 @@ const getRegistry = () => {
 
 const reportMetrics = (context) =>  {
   if(context != null){
-    let invokedFunctionArn = context.invokedFunctionArn
-    let splitArn = invokedFunctionArn.split(":")
+    let invokedFunctionArn = context.invokedFunctionArn;
+    let splitArn = invokedFunctionArn.split(":");
+    let [prefixArn, prefixAws, prefixLambda, region, accountId, functionOrEventSource, functionNameOrEventSourceId, versionOrAlias] = splitArn;
 
     // Expected formats for Lambda ARN are:
     // https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-lambda
@@ -123,16 +124,16 @@ const reportMetrics = (context) =>  {
       "source":          context.functionName,
       "FunctionName":    context.functionName,
       "ExecutedVersion": context.functionVersion,
-      "Region":          splitArn[3],
-      "accountId":       splitArn[4]
+      "Region":          region,
+      "accountId":       accountId
     }
-    if (splitArn[5] === "function") {
-      tags["Resource"] = splitArn[6]
+    if (functionOrEventSource === "function") {
+      tags["Resource"] = functionNameOrEventSourceId
       if (splitArn.length === 8) {
-        tags["Resource"] += ":" + splitArn[7]
+        tags["Resource"] += ":" + versionOrAlias
       }
-    } else if (splitArn[5] === "event-source-mappings") {
-      tags["EventSourceMappings"] = splitArn[6]
+    } else if (functionOrEventSource === "event-source-mappings") {
+      tags["EventSourceMappings"] = functionNameOrEventSourceId
     }
 
     try{

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -84,7 +84,7 @@ const incrementMetric = function (metricName, value) {
         durationValue.inc(value);
         break;
     default:
-         console.log("Warn :: No standard lambda metric was matched.");
+         console.warn("No standard lambda metric matched.");
   }
 }
 

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,0 +1,51 @@
+const wavefrontReporter = require('./reporter');
+
+const wrapper = (lambdaHandlerFunction) => function (event, context, callback){
+    console.log("INSIDE:: wavefrontWrapper")
+    // Register standard lambda metrics with the registry.
+    wavefrontReporter.registerStandardLambdaMetrics();
+    let isWrapperCallbackExecuted = false;
+    const wrappercallback = (error, successmesssage) =>{
+      // Increment error counter as required.
+      if(error !== undefined && error !==null){
+          console.log("INCREMENT:: Error counter from callback")
+          wavefrontReporter.incrementErrors();
+      }
+      console.log('CALCULATE::  duration from callback');
+      wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
+      isWrapperCallbackExecuted = true;
+      // Report metrics.
+      wavefrontReporter.reportMetrics(context);
+      callback(error, successmesssage);
+    }
+
+    // Increment invocation counter.
+    wavefrontReporter.incrementInvocations();
+    const startTime = process.hrtime();
+    try {
+      lambdaHandlerFunction(event, context, wrappercallback)
+      // Handle the case when function completed with success but didn't call the wrappedCallback().
+      process.on('beforeExit', function() {
+        if(!isWrapperCallbackExecuted){
+          console.log("CALCULATE:: Duration from process.beforeExit")
+          wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000);
+          wavefrontReporter.reportMetrics(context);
+        }
+      });
+      console.log("SamplePrintStatement");
+    }catch(err){
+      // wrappercallback(err, null)
+      //increment error counters and rpeort points.
+      console.log("INCREMENT:: Error counter and calculate duration from catch")
+      wavefrontReporter.incrementErrors();
+      wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
+      wavefrontReporter.reportMetrics(context);
+      throw err;
+    }
+}
+
+const getRegistry = () => {
+  return wavefrontReporter.getRegistry();
+}
+
+module.exports = {wrapper, getRegistry};

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,21 +1,21 @@
 const wavefrontReporter = require('./reporter');
 
 const wrapper = (lambdaHandlerFunction) => function (event, context, callback){
-    console.log("INSIDE:: wavefrontWrapper")
     // Register standard lambda metrics with the registry.
     wavefrontReporter.registerStandardLambdaMetrics();
+    // Keep track if wrappedCallBack is called, otherwise
+    // register beforeExit event to report metrics to wavefront.
     let isWrapperCallbackExecuted = false;
     const wrappercallback = (error, successmesssage) =>{
       // Increment error counter as required.
       if(error !== undefined && error !==null){
-          console.log("INCREMENT:: Error counter from callback")
           wavefrontReporter.incrementErrors();
       }
-      console.log('CALCULATE::  duration from callback');
       wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
       isWrapperCallbackExecuted = true;
       // Report metrics.
       wavefrontReporter.reportMetrics(context);
+      // Return control to AWS Lambda.
       callback(error, successmesssage);
     }
 
@@ -24,20 +24,19 @@ const wrapper = (lambdaHandlerFunction) => function (event, context, callback){
     const startTime = process.hrtime();
     try {
       lambdaHandlerFunction(event, context, wrappercallback)
-      // Handle the case when function completed with success but didn't call the wrappedCallback().
-      process.on('beforeExit', function() {
-        if(!isWrapperCallbackExecuted){
-          console.log("CALCULATE:: Duration from process.beforeExit")
-          wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000);
-          wavefrontReporter.reportMetrics(context);
-        }
-      });
-      console.log("SamplePrintStatement");
+      // Handle the case when original lambda handler function completes successfully but doesn't call the Callback().
+      if(context.callbackWaitsForEmptyEventLoop){
+        process.on('beforeExit', function() {
+          if(!isWrapperCallbackExecuted){
+            wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000);
+            wavefrontReporter.reportMetrics(context);
+          }
+        });
+      }
     }catch(err){
-      // wrappercallback(err, null)
-      //increment error counters and rpeort points.
-      console.log("INCREMENT:: Error counter and calculate duration from catch")
+      // Increment error counters.
       wavefrontReporter.incrementErrors();
+      // Update duration.
       wavefrontReporter.updateDuration(process.hrtime(startTime)[1] / 1000000)
       wavefrontReporter.reportMetrics(context);
       throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "wavefront-lambda",
+  "version": "0.9.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
+    },
+    "metrics": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/metrics/-/metrics-0.1.16.tgz",
+      "integrity": "sha512-8rqaGV0cI/DgbIPDq2t+qE0ifvu+T9hxjQdaqzdJwCD8bvxiGHhx0gr6Vm/MDPxP9fZSSw+GdfuBmvQcl2Zl1g==",
+      "requires": {
+        "events": "^2.0.0"
+      }
+    },
+    "wavefrontmetrics": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wavefrontmetrics/-/wavefrontmetrics-1.0.1.tgz",
+      "integrity": "sha512-O6/menw7arrr5/v0ZkqlNrDR/r4wKgb6qx9t6BrPXaY72iHUtnze3YuRAHHgyX8BU7BYCmFxjuLX25vXuodQCA==",
+      "requires": {
+        "metrics": "^0.1.11"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
         "events": "^2.0.0"
       }
     },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
     "wavefrontmetrics": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wavefrontmetrics/-/wavefrontmetrics-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "wavefront-lambda",
+  "version": "0.9.0",
+  "description": "Wavefront Lambda Wrapper to direcly report metrics from AWS Lambda functions.",
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wavefrontHQ/wavefront-lambda-nodejs.git"
+  },
+  "keywords": [
+    "lambda",
+    "wrapper",
+    "serverless",
+    "wavefront",
+    "vmware"
+  ],
+  "author": "Anil Kodali <akodali@vmware.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wavefrontHQ/wavefront-lambda-nodejs/issues"
+  },
+  "homepage": "https://github.com/wavefrontHQ/wavefront-lambda-nodejs#readme",
+  "dependencies": {
+    "wavefrontmetrics": "^1.0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/wavefrontHQ/wavefront-lambda-nodejs#readme",
   "dependencies": {
+    "semver": "^5.5.0",
     "wavefrontmetrics": "^1.0.1"
   }
 }


### PR DESCRIPTION
Adding nodejs wrapper for AWS lambda.
Caveats: 
Currently works with only nodejs 8.10 as:
metrics client library  https://github.com/wavefrontHQ/nodejs-metrics-wavefront requires > v8.0 


Currently works only if original lambda function is not async.
 This is because reporting points to wavefront is currently a non-blocking call and there is no way to get the status of the report request from https://github.com/wavefrontHQ/nodejs-metrics-wavefront libraries. As, AWS freezes the nodejs process as soon as returned promise from async function is resolved, the call to report points to wavefront might not be triggered before the node process is freezed.

Please review: @vikramraman @aliu-vmware @sushantdewan123 


Thank you,
Anil