### PR TITLE
MONIT-10728 Remove event counters from lambda wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,8 @@ The Lambda wrapper sends the following standard lambda metrics to wavefront:
 | Metric Name                       |  Type              | Description                                                             |
 | ----------------------------------|:------------------:| ----------------------------------------------------------------------- |
 | aws.lambda.wf.invocations.count   | Delta Counter      | Count of number of lambda function invocations aggregated at the server.|
-| aws.lambda.wf.invocation_event.count   |  Counter      | Count of number of lambda function invocations.|
 | aws.lambda.wf.errors.count        | Delta Counter      | Count of number of errors aggregated at the server.                     |
-| aws.lambda.wf.error_event.count        |  Counter      | Count of number of errors.                     |
 | aws.lambda.wf.coldstarts.count    | Delta Counter      | Count of number of cold starts aggregated at the server.                |
-| aws.lambda.wf.coldstart_event.count| Counter           | Count of number of cold starts.                                         |
 | aws.lambda.wf.duration.value      | Gauge              | Execution time of the Lambda handler function in milliseconds.          |
 
 The Lambda wrapper adds the following point tags to all metrics sent to wavefront:

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,11 +16,8 @@ const metricPrefix = "aws.lambda.wf.";
 // Standard Lambda Metrics reported by wrapper.
 const standardLambdaMetrics = {
   invocationsCounter : metricPrefix + 'invocations.count',
-  invocationEventCounter : metricPrefix + 'invocation_event.count',
   coldStartsCounter : metricPrefix + 'coldstarts.count',
-  coldStartEventCounter : metricPrefix + 'coldstart_event.count',
   errorsCounter : metricPrefix + 'errors.count',
-  errorEventCounter : metricPrefix + 'error_event.count',
   durationValue : metricPrefix + 'duration.value'
 };
 let isColdStart = true;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -17,7 +17,7 @@ const registerStandardLambdaMetrics = () => {
   // Register Standard Lambda Metrics as Counters.
   standardMetrics = standardMetricsKeys.reduce((metricObj, name) => {
       metricObj[name] = new metrics.Counter();
-      if(name.includes('event') || name.includes('value')) {
+      if(name.includes('value')) {
         registry.addTaggedMetric(name, metricObj[name]);
       } else{
         let deltaName = metrics.deltaCounterName(name);
@@ -44,17 +44,14 @@ const incrementMetric = function (metricName, value) {
 }
 
 const incrementInvocations = function(){
-  incrementMetric(config.standardLambdaMetrics.invocationEventCounter, 1)
   incrementMetric(config.standardLambdaMetrics.invocationsCounter, 1)
 }
 
 const incrementErrors = function(){
-  incrementMetric(config.standardLambdaMetrics.errorEventCounter, 1)
   incrementMetric(config.standardLambdaMetrics.errorsCounter, 1)
 }
 
 const incrementColdStarts = function(){
-  incrementMetric(config.standardLambdaMetrics.coldStartEventCounter, 1)
   incrementMetric(config.standardLambdaMetrics.coldStartsCounter, 1)
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavefront-lambda",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Wavefront Lambda Wrapper to direcly report metrics from AWS Lambda functions.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Removing event counters from lambda wrappers as they are redundant , given the existence of delta counter metrics.

Please review. Cc @vikramraman 

Thank you,
Anil